### PR TITLE
Make bad report name really bad.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.7.1, <4.0"
-importlib_resources = "*"
 pandas = "1.3.5"
 
 [tool.poetry.dev-dependencies]

--- a/src/redcapmatchresolver/redcap_clinic.py
+++ b/src/redcapmatchresolver/redcap_clinic.py
@@ -5,7 +5,7 @@ clinic location.
 """
 import os.path
 
-import importlib_resources as pkg_resources  # type: ignore[import]
+from importlib import resources  # type: ignore[import]
 import pandas  # type: ignore[import]
 
 
@@ -16,7 +16,7 @@ class REDCapClinic:  # pylint: disable=too-few-public-methods
 
     def __init__(self) -> None:
         #   Read Excel file. https://stackoverflow.com/a/67122465/20241849
-        with pkg_resources.path(
+        with resources.path(
             "redcapmatchresolver.data", "Epic DEP with future appts - 04192022 .xlsx"
         ) as excel_filename:  # pragma: no cover
             if not os.path.exists(excel_filename):

--- a/tests/test_report_writer.py
+++ b/tests/test_report_writer.py
@@ -24,9 +24,10 @@ def test_writer_init(tmp_path) -> None:
     assert isinstance(obj, REDCapReportWriter)
     assert obj.report_filename() == tmp_filename
 
-    # Unrealizable report name.
+    # Unrealizable report name with NULL character.
     with pytest.raises(OSError):
-        bad_filename = str(tmp_path / "name that can't be </parsed.txt")
+        just_the_filename = "name that can't be </parsed" + '\0' + ".txt"
+        bad_filename = str(tmp_path / just_the_filename)
         REDCapReportWriter(report_filename=bad_filename)
 
 


### PR DESCRIPTION
## Description

1. Make bad report name really bad by inserting a NULL character.
2. Switch to built-in `importlib.resources` library as recommended in https://stackoverflow.com/a/67122465/20241849 

## Checklist

- [ ] Tests covering the new functionality have been added
- [ ] Documentation has been updated OR the change is too minor to be documented
- [ ] Changes are listed in the `CHANGELOG.md` OR changes are insignificant
