### PR TITLE
Make report name too long.

### DIFF
--- a/tests/test_report_writer.py
+++ b/tests/test_report_writer.py
@@ -26,7 +26,7 @@ def test_writer_init(tmp_path) -> None:
 
     # Report name that contains forbidden characters and is too long.
     with pytest.raises(OSError):
-        just_the_filename = "name that can't be /<>parsed" * 15 + '\0' + ".txt"
+        just_the_filename = r"name that can't be? :/<parsed*?.txt"
         bad_filename = str(tmp_path / just_the_filename)
         REDCapReportWriter(report_filename=bad_filename)
 

--- a/tests/test_report_writer.py
+++ b/tests/test_report_writer.py
@@ -24,9 +24,9 @@ def test_writer_init(tmp_path) -> None:
     assert isinstance(obj, REDCapReportWriter)
     assert obj.report_filename() == tmp_filename
 
-    # Unrealizable report name with NULL character.
+    # Report name that contains forbidden characters and is too long.
     with pytest.raises(OSError):
-        just_the_filename = "name that can't be </parsed" + '\0' + ".txt"
+        just_the_filename = "name that can't be /<>parsed" * 15 + '\0' + ".txt"
         bad_filename = str(tmp_path / just_the_filename)
         REDCapReportWriter(report_filename=bad_filename)
 


### PR DESCRIPTION
## Description

Make report name too long.

## Checklist

- [ ] Tests covering the new functionality have been added
- [ ] Documentation has been updated OR the change is too minor to be documented
- [ ] Changes are listed in the `CHANGELOG.md` OR changes are insignificant
